### PR TITLE
added @polkadot/x-textdecoder and @polkadot/x-bigint-shim to moduleNameMapper in jest.config

### DIFF
--- a/lib/dotbot-core/jest.config.js
+++ b/lib/dotbot-core/jest.config.js
@@ -28,7 +28,9 @@ module.exports = {
     '^@polkadot/rpc-core/types/(.*)$': '<rootDir>/../../node_modules/@polkadot/rpc-core/cjs/types/$1',
     '^@polkadot/([^/]+)/(?!cjs/)(.+)$': '<rootDir>/../../node_modules/@polkadot/$1/cjs/$2',
     '^@polkadot/x-bigint$': '<rootDir>/../../node_modules/@polkadot/x-bigint/cjs/index.js',
-    '^@polkadot/x-bigint/shim$': '<rootDir>/../../node_modules/@polkadot/x-bigint/cjs/shim.js'
+    '^@polkadot/x-bigint/shim$': '<rootDir>/../../node_modules/@polkadot/x-bigint/cjs/shim.js',
+    '^@polkadot/x-textdecoder$': '<rootDir>/../../node_modules/@polkadot/x-textdecoder/cjs/node.js',
+    '^@polkadot/x-textencoder$': '<rootDir>/../../node_modules/@polkadot/x-textencoder/cjs/node.js'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/']


### PR DESCRIPTION
```
  moduleNameMapper: {
    '^@polkadot/rpc-core/types/(.*)$': '<rootDir>/../../node_modules/@polkadot/rpc-core/cjs/types/$1',
    '^@polkadot/([^/]+)/(?!cjs/)(.+)$': '<rootDir>/../../node_modules/@polkadot/$1/cjs/$2',
    '^@polkadot/x-bigint$': '<rootDir>/../../node_modules/@polkadot/x-bigint/cjs/index.js',
    '^@polkadot/x-bigint/shim$': '<rootDir>/../../node_modules/@polkadot/x-bigint/cjs/shim.js',
    '^@polkadot/x-textdecoder$': '<rootDir>/../../node_modules/@polkadot/x-textdecoder/cjs/node.js',
    '^@polkadot/x-textencoder$': '<rootDir>/../../node_modules/@polkadot/x-textencoder/cjs/node.js'
  },

```