### PR TITLE
Restart mechanism and LOG_LEVEL sot to INFO in production as well

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -187,7 +187,7 @@ jobs:
         cat > deploy/.env << EOF
         NODE_ENV=production
         DEBUG=false
-        LOG_LEVEL=warn
+        LOG_LEVEL=info
         LOG_FORMAT=json
         
         # Domain Configuration
@@ -256,6 +256,12 @@ jobs:
             environment:
               - NODE_ENV=production
             restart: always
+            healthcheck:
+              test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+              interval: 30s
+              timeout: 10s
+              retries: 3
+              start_period: 10s
             networks:
               - dotbot-production
         
@@ -276,6 +282,12 @@ jobs:
               - LOG_LEVEL=${LOG_LEVEL:-info}
               - LOG_FORMAT=json
             restart: always
+            healthcheck:
+              test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+              interval: 30s
+              timeout: 10s
+              retries: 3
+              start_period: 10s
             networks:
               - dotbot-production
             depends_on:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -41,6 +41,7 @@ services:
       - AI_PROVIDER=${AI_PROVIDER:-asi-one}
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_FORMAT=${LOG_FORMAT:-json}
       - STORAGE_DIR=/app/backend/data/storage
     volumes:
       - backend-data:/app/backend/data


### PR DESCRIPTION
### Description: 
Adds restart mechanism

####  Build/Config Changes
 - added `LOG_FORMAT=json` and `LOG_LEVEL` was set to `info` so Grafana will read logs properly, in production as well
 - added a _healthcheck_ to the workflow, so `restart: always` will restart the container, if it fails 