### PR TITLE
Fixes the error ScenarioEngine not detecting transaction failure

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1361,10 +1361,14 @@ interface ChatOptions {
 interface ChatResult {
   response: string;
   plan?: ExecutionPlan;
+  executionArrayState?: ExecutionArrayState;  // Stateless mode: prepared state for client
+  executionId?: string;                         // Pass to startExecution()
   executed: boolean;
   success: boolean;
   completed: number;
   failed: number;
+  executionErrors?: string[];                  // When executed and some items failed (e.g. "Transaction Invalid")
+  backendSimulated?: boolean;
 }
 ```
 
@@ -1377,10 +1381,13 @@ interface ChatResult {
 **Returns:**
 - `response` (string): Bot's response or execution result
 - `plan` (ExecutionPlan, optional): Extracted execution plan if found
-- `executed` (boolean): Whether execution occurred (v0.2.0: always false until user approves)
-- `success` (boolean): Whether operation succeeded
-- `completed` (number): Number of completed operations
-- `failed` (number): Number of failed operations
+- `executionId` (string, optional): Id to pass to `startExecution()` when a plan was prepared
+- `executed` (boolean): `false` when returned from `chat()` (user must approve). After execution completes (e.g. in ScenarioEngine or when polling), callers may see an updated result with `executed: true` and final counts.
+- `success` (boolean): When `executed` is true, whether all execution items succeeded
+- `completed` (number): When `executed` is true, number of items that completed successfully
+- `failed` (number): When `executed` is true, number of items that failed
+- `executionErrors` (string[], optional): When `executed` is true and some items failed, error messages (e.g. `["Transaction Invalid"]`)
+- `backendSimulated` (boolean, optional): Whether the backend ran Chopsticks simulation for this flow
 
 **Behavior (v0.2.0):**
 1. Saves user message to chat history

--- a/lib/dotbot-core/dotbot/types.ts
+++ b/lib/dotbot-core/dotbot/types.ts
@@ -66,6 +66,8 @@ export interface ChatResult {
   success: boolean;
   completed: number;
   failed: number;
+  /** Error messages from execution items that failed (e.g. "Transaction Invalid"). */
+  executionErrors?: string[];
   /** True when backend ran simulation. */
   backendSimulated?: boolean;
 }

--- a/lib/dotbot-core/scenarioEngine/types.ts
+++ b/lib/dotbot-core/scenarioEngine/types.ts
@@ -609,6 +609,9 @@ export interface StepResult {
     completed: number;
     failed: number;
   };
+
+  /** Error messages from execution items that failed (e.g. "Transaction Invalid"). */
+  executionErrors?: string[];
   
   /** Error if step failed */
   error?: {
@@ -675,6 +678,9 @@ export interface EvaluationResult {
   
   /** Recommendations */
   recommendations?: string[];
+
+  /** Error messages from execution failures (e.g. "Transaction Invalid"). Present when execution ran but had failures. */
+  executionErrors?: string[];
 }
 
 // =============================================================================


### PR DESCRIPTION
### Description: 
Fixes the error `ScenarioEngine` not detecting transaction failure.

### What was changed:
#### Core Changes:
 - added `executionErrors` to `ChatResult` and `StepResult`
 - added mechanism to detect execution error, so ScenarioEngine will include it in the results

#### Test Related Changes
 - `Execution failure detection` unit tests
 - added related unit tests to ScenarioExecutor unit tests

### How was it tested:
`npm run test`
manually tested