### PR TITLE
Never use Planck

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,9 +1,5 @@
 # Known Issues
 
-## Transfer amount defaults to Planck
-
-Sometimes the transfer amount is understood as Planck
-
 ## Westend transfer sometimes failes
 
 Westend sometimes gives back `Transaction Invalid `
@@ -17,7 +13,8 @@ This is what we know from SubWallet:
 Most likely this is related to Westend not being stable at the moment.
 We did not used to have this issue previously.
 Polkadot.js gives the same error as of now.
-
-## ScenarioEngine does not traslates addresses like Alice
-
 When evaluating, the ScenarioEngine does not translate addresses like Alice, will give failure for matching address.
+
+## Sometimes DotBot gets stuck at "Preparing transaction flow..."
+
+Sometimes DotBot gets stuck at "Preparing transaction flow..." (rare)

--- a/lib/dotbot-core/agents/asset-transfer/types.ts
+++ b/lib/dotbot-core/agents/asset-transfer/types.ts
@@ -15,7 +15,7 @@ export interface TransferParams extends BaseAgentParams {
   /** Recipient address */
   recipient: string;
   
-  /** Amount to transfer (can be in human-readable format like "1.5" or in Planck like "15000000000") */
+  /** Amount to transfer in human token units (e.g. "1", "1.5", 5). Always converted to Planck internally. */
   amount: string | number;
   
   /** Target chain for the transfer - defaults to 'assetHub' for DOT */
@@ -32,6 +32,7 @@ export interface BatchTransferParams extends BaseAgentParams {
   /** Array of transfers */
   transfers: Array<{
     recipient: string;
+    /** Amount in human token units (e.g. "1", "1.5"). Always converted to Planck internally. */
     amount: string | number;
   }>;
   

--- a/lib/dotbot-core/agents/asset-transfer/utils/amountNormalizer.ts
+++ b/lib/dotbot-core/agents/asset-transfer/utils/amountNormalizer.ts
@@ -2,21 +2,20 @@
  * Amount Normalization Utilities
  * 
  * Provides amount conversion functions for different input formats.
+ * Integer amounts (e.g. "1", 5) are interpreted as human token units (1 DOT, 5 DOT), not Planck.
  */
 
 import { BN } from '@polkadot/util';
 import { TransferCapabilities } from './transferCapabilities';
+import { integerAmountToPlanck } from './amountParser';
 
 /**
- * Normalize amount to BN, handling different input formats
- * 
- * Accepts:
- * - BN object (passthrough)
- * - Number (converted to BN)
- * - String integer: "15000000000" (converted to BN)
- * - String decimal: "1.5" (converted to Planck using chain decimals)
- * 
- * @param amount Amount in various formats
+ * Normalize amount to BN (Planck), handling different input formats.
+ *
+ * All string/number inputs are treated as human token units (DOT, KSM, etc.);
+ * they are converted to Planck using chain decimals. BN inputs are passed through.
+ *
+ * @param amount Amount in various formats (human string/number or BN already in Planck)
  * @param capabilities Chain capabilities for decimal conversion
  * @returns Amount as BN in smallest unit (Planck)
  */
@@ -30,9 +29,9 @@ export function normalizeAmountToBN(
 
   if (typeof amount === 'number') {
     if (!Number.isInteger(amount) || amount < 0) {
-      throw new Error(`Invalid amount: ${amount}. Must be a positive integer in Planck.`);
+      throw new Error(`Invalid amount: ${amount}. Must be a positive integer.`);
     }
-    return new BN(amount);
+    return integerAmountToPlanck(amount, capabilities.nativeDecimals);
   }
 
   if (typeof amount === 'string') {
@@ -60,7 +59,7 @@ export function normalizeAmountToBN(
       throw new Error(`Invalid amount format: ${amount}. Must be integer or decimal string.`);
     }
 
-    return new BN(amount);
+    return integerAmountToPlanck(amount, capabilities.nativeDecimals);
   }
 
   throw new Error(`Unsupported amount type: ${typeof amount}`);

--- a/lib/dotbot-core/scenarioEngine/components/ScenarioExecutor.ts
+++ b/lib/dotbot-core/scenarioEngine/components/ScenarioExecutor.ts
@@ -63,6 +63,7 @@ import {
   CALCULATION_FUNCTIONS,
   type CalculationContext,
 } from './expressionCalculations';
+import { integerAmountToPlanck, parseAmount } from '../../agents/asset-transfer/utils/amountParser';
 
 // =============================================================================
 // TYPES
@@ -1241,8 +1242,11 @@ export class ScenarioExecutor {
       throw new Error(`Entity address not found for ${fromEntity}`);
     }
 
-    // Parse amount to BN
-    const amountBN = new BN(amount);
+    // Amount is always in human token units (e.g. "1", "0.5") → convert to Planck
+    const decimals = this.deps!.api.registry.chainDecimals?.[0] ?? 10;
+    const amountBN = amount.includes('.')
+      ? parseAmount(amount, decimals)
+      : integerAmountToPlanck(amount, decimals);
     
     // Create transfer extrinsic
     const transferExtrinsic = this.deps!.api.tx.balances.transferKeepAlive(

--- a/lib/dotbot-core/tests/unit/agents/asset-transfer/assetTransfer.test.ts
+++ b/lib/dotbot-core/tests/unit/agents/asset-transfer/assetTransfer.test.ts
@@ -106,7 +106,7 @@ describe('AssetTransferAgent', () => {
         const result = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         });
 
         expect(result.extrinsic).toBeDefined();
@@ -131,7 +131,7 @@ describe('AssetTransferAgent', () => {
         const result = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
           keepAlive: true,
         });
 
@@ -161,7 +161,7 @@ describe('AssetTransferAgent', () => {
         const result = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         });
 
         expect(result.estimatedFee).toBeDefined();
@@ -174,7 +174,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.transfer({
           address: INVALID_ADDRESSES.EMPTY,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         }).catch((e: unknown) => e) as AgentError;
 
         expect(error).toBeInstanceOf(AgentError);
@@ -185,7 +185,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: INVALID_ADDRESSES.EMPTY,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         }).catch(e => e);
 
         expect(error).toBeInstanceOf(AgentError);
@@ -196,7 +196,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.ALICE,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         }).catch(e => e);
 
         expect(error).toBeInstanceOf(AgentError);
@@ -233,7 +233,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT, // 1 DOT, but only 0.1 DOT available
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT, // 1 DOT, but only 0.1 DOT available
         }).catch(e => e);
 
         expect(error).toBeInstanceOf(AgentError);
@@ -249,7 +249,7 @@ describe('AssetTransferAgent', () => {
         const result = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
           validateBalance: false,
         });
 
@@ -264,7 +264,7 @@ describe('AssetTransferAgent', () => {
         const error = await uninitializedAgent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         }).catch(e => e);
 
         expect(error).toBeInstanceOf(AgentError);
@@ -279,7 +279,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.transfer({
           address: TEST_ADDRESSES.ALICE,
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_DOT,
+          amount: TEST_AMOUNTS_HUMAN.ONE_DOT,
         }).catch(e => e);
 
         expect(error).toBeInstanceOf(AgentError);
@@ -294,8 +294,8 @@ describe('AssetTransferAgent', () => {
         const result = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
-            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS.HALF_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
+            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS_HUMAN.HALF_DOT },
           ],
         });
 
@@ -311,8 +311,8 @@ describe('AssetTransferAgent', () => {
         const result = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
-            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS.HALF_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
+            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS_HUMAN.HALF_DOT },
           ],
         });
 
@@ -338,7 +338,7 @@ describe('AssetTransferAgent', () => {
       it('should throw AgentError for more than 100 transfers', async () => {
         const tooManyTransfers = Array.from({ length: 101 }, (_, i) => ({
           recipient: TEST_ADDRESSES.BOB,
-          amount: TEST_AMOUNTS.ONE_PLANCK,
+          amount: TEST_AMOUNTS_HUMAN.SMALL,
         }));
 
         const error = await agent.batchTransfer({
@@ -354,8 +354,8 @@ describe('AssetTransferAgent', () => {
         const error = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
-            { recipient: INVALID_ADDRESSES.EMPTY, amount: TEST_AMOUNTS.ONE_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
+            { recipient: INVALID_ADDRESSES.EMPTY, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
           ],
         }).catch(e => e);
 
@@ -367,8 +367,8 @@ describe('AssetTransferAgent', () => {
         const error = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
-            { recipient: TEST_ADDRESSES.ALICE, amount: TEST_AMOUNTS.ONE_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
+            { recipient: TEST_ADDRESSES.ALICE, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
           ],
         }).catch(e => e);
 
@@ -396,8 +396,8 @@ describe('AssetTransferAgent', () => {
         const error = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
-            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS.ONE_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
+            { recipient: TEST_ADDRESSES.CHARLIE, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
           ],
         }).catch(e => e);
 
@@ -413,7 +413,7 @@ describe('AssetTransferAgent', () => {
         const error = await uninitializedAgent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
           ],
         }).catch(e => e);
 
@@ -431,7 +431,7 @@ describe('AssetTransferAgent', () => {
         const error = await agent.batchTransfer({
           address: TEST_ADDRESSES.ALICE,
           transfers: [
-            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS.ONE_DOT },
+            { recipient: TEST_ADDRESSES.BOB, amount: TEST_AMOUNTS_HUMAN.ONE_DOT },
           ],
         }).catch(e => e);
 

--- a/lib/dotbot-core/tests/unit/agents/asset-transfer/utils/amountNormalizer.test.ts
+++ b/lib/dotbot-core/tests/unit/agents/asset-transfer/utils/amountNormalizer.test.ts
@@ -42,11 +42,12 @@ describe('Amount Normalizer Utilities', () => {
       expect(result.toString()).toBe('1000000000000');
     });
 
-    it('should convert number to BN', () => {
+    it('should convert number to BN (as human token units)', () => {
       const result = normalizeAmountToBN(1000000000000, mockCapabilities);
 
       expect(BN.isBN(result)).toBe(true);
-      expect(result.toString()).toBe('1000000000000');
+      // 1000000000000 DOT with 10 decimals = 1000000000000 * 10^10 planck
+      expect(result.toString()).toBe('10000000000000000000000');
     });
 
     it('should throw error for negative number', () => {
@@ -67,10 +68,19 @@ describe('Amount Normalizer Utilities', () => {
       expect(result.toString()).toBe('15000000000'); // 1.5 * 10^10
     });
 
-    it('should parse integer string', () => {
+    it('should treat all integer strings as human token units', () => {
       const result = normalizeAmountToBN('1000000000000', mockCapabilities);
+      expect(result.toString()).toBe('10000000000000000000000'); // 1e12 DOT = 1e12 * 1e10 Planck
+    });
 
-      expect(result.toString()).toBe('1000000000000');
+    it('should treat integer string "1" as 1 DOT', () => {
+      const result = normalizeAmountToBN('1', mockCapabilities);
+      expect(result.toString()).toBe('10000000000');
+    });
+
+    it('should treat integer number as human (1 → 1 DOT)', () => {
+      const result = normalizeAmountToBN(1, mockCapabilities);
+      expect(result.toString()).toBe('10000000000');
     });
 
     it('should throw error for too many decimal places', () => {

--- a/lib/dotbot-core/tests/unit/agents/asset-transfer/utils/amountParser.test.ts
+++ b/lib/dotbot-core/tests/unit/agents/asset-transfer/utils/amountParser.test.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  integerAmountToPlanck,
   parseAndValidateAmountWithCapabilities,
   parseAmount,
   formatAmount,
@@ -36,6 +37,17 @@ describe('Amount Parser Utilities', () => {
       specName: 'polkadot',
       specVersion: 1,
     };
+  });
+
+  describe('integerAmountToPlanck()', () => {
+    it('should always treat integer as human token units ("1" = 1 DOT)', () => {
+      expect(integerAmountToPlanck('1', 10).toString()).toBe('10000000000');
+      expect(integerAmountToPlanck('5', 10).toString()).toBe('50000000000');
+      expect(integerAmountToPlanck(1, 10).toString()).toBe('10000000000');
+    });
+    it('should multiply by 10^decimals (no heuristic)', () => {
+      expect(integerAmountToPlanck('10000000000', 10).toString()).toBe('100000000000000000000');
+    });
   });
 
   describe('parseAmount()', () => {
@@ -144,6 +156,16 @@ describe('Amount Parser Utilities', () => {
       const result = parseAndValidateAmountWithCapabilities(1.5, mockCapabilities);
 
       expect(result.toString()).toBe('15000000000');
+    });
+
+    it('should treat integer string "1" as 1 DOT (not 1 Planck)', () => {
+      const result = parseAndValidateAmountWithCapabilities('1', mockCapabilities);
+      expect(result.toString()).toBe('10000000000');
+    });
+
+    it('should treat integer string "10000000000" as 10e9 DOT (human)', () => {
+      const result = parseAndValidateAmountWithCapabilities('10000000000', mockCapabilities);
+      expect(result.toString()).toBe('100000000000000000000');
     });
 
     it('should include index in error message for batch transfers', () => {


### PR DESCRIPTION
### Description: 
Input number always as human readable, never use Planck. The issue mostly occurred, when input number was an integer, like "1'.

### What was changed:
#### Core Changes:
 - updated known issues
 - always do `integerAmountToPlanck(amount, capabilities.nativeDecimals)` in `normalizeAmountToBN`

#### Test Related Changes
 - adjusted unit tests

### How was it tested:
`npm run test`
manually tested