### PR TITLE
Connect to RPC endpoints in the background when opening new chat

### DIFF
--- a/frontend/src/utils/connectionErrorModal.ts
+++ b/frontend/src/utils/connectionErrorModal.ts
@@ -1,0 +1,12 @@
+/**
+ * Global trigger for the connection error modal.
+ * Use this from any context (async callbacks, promise chains) so the modal always shows.
+ */
+
+export const SHOW_CONNECTION_ERROR_EVENT = 'dotbot-show-connection-error';
+
+export function showConnectionErrorModal(message: string): void {
+  window.dispatchEvent(
+    new CustomEvent(SHOW_CONNECTION_ERROR_EVENT, { detail: { message } })
+  );
+}


### PR DESCRIPTION
### Description: 
When connecting to a chat, load RPC connections in the background, so it does not block the UI.

### What was changed:
#### Core Changes:
 - added `initPromise` to `ExecutionSessionManager.initialize()`
 - changed `initSessionsForCurrentChat` and `initializeChatInstance`, so they don't wait for rpc connections, and don't block the UI

### How was it tested:
`npm run test`
manually tested