### PR TITLE
Don't guess insufficient amount

### DIFF
--- a/lib/dotbot-core/scenarioEngine/components/expressionCalculations.ts
+++ b/lib/dotbot-core/scenarioEngine/components/expressionCalculations.ts
@@ -144,6 +144,29 @@ export async function calculateBalancePlusAmount(
 }
 
 /**
+ * Single-transfer insufficient balance: amount that is always more than current balance.
+ * Use for "should fail (insufficient balance)" tests. Returns balance + 1, or 1 if balance is 0,
+ * so we never accidentally request a transferable amount (e.g. 0.01 when balance is 0).
+ * No args.
+ */
+export async function calculateMoreThanBalance(
+  _args: string[],
+  context: CalculationContext
+): Promise<string> {
+  const userAddress = await context.getUserAddress();
+  const { balance } = await queryBalance(context.api, userAddress);
+  const result = balance > 0 ? balance + 1 : 1;
+
+  context.emit?.({
+    type: 'log',
+    level: 'info',
+    message: `More-than-balance: balance ${balance.toFixed(4)} → amount ${result.toFixed(2)} (always insufficient)`
+  });
+
+  return result.toFixed(2);
+}
+
+/**
  * Calculate a safe transfer amount that would succeed individually
  * 
  * Args: [reserveAmount, estimatedFee]
@@ -184,6 +207,7 @@ export const CALCULATION_FUNCTIONS: Record<
   (args: string[], context: CalculationContext) => Promise<string>
 > = {
   insufficientBalance: calculateInsufficientBalance,
+  moreThanBalance: calculateMoreThanBalance,
   currentBalance: getCurrentBalance,
   balanceMinusAmount: calculateBalanceMinusAmount,
   balancePlusAmount: calculateBalancePlusAmount,

--- a/lib/dotbot-core/scenarioEngine/scenarios/scenarioHelpers.ts
+++ b/lib/dotbot-core/scenarioEngine/scenarios/scenarioHelpers.ts
@@ -226,8 +226,8 @@ export function transferScenario(config: {
 
 /**
  * Insufficient balance scenario.
- * Use a dynamic amount so we never guess: e.g. amount: '{{calc:balancePlusAmount(0.01)}}'
- * (current balance + 0.01 is always insufficient, works on any network and burns nothing).
+ * Use dynamic amount so we never guess: amount: '{{calc:moreThanBalance()}}'
+ * (returns balance+1 or 1 if balance 0; always insufficient, works on any network).
  */
 export function insufficientBalanceScenario(config: {
   id: string;

--- a/lib/dotbot-core/scenarioEngine/scenarios/scenarioHelpers.ts
+++ b/lib/dotbot-core/scenarioEngine/scenarios/scenarioHelpers.ts
@@ -225,18 +225,21 @@ export function transferScenario(config: {
 }
 
 /**
- * Insufficient balance scenario
+ * Insufficient balance scenario.
+ * Use a dynamic amount so we never guess: e.g. amount: '{{calc:balancePlusAmount(0.01)}}'
+ * (current balance + 0.01 is always insufficient, works on any network and burns nothing).
  */
 export function insufficientBalanceScenario(config: {
   id: string;
   name: string;
+  /** Amount in prompt; use {{calc:balancePlusAmount(0.01)}} for dynamic (recommended). */
   amount: string;
   recipient: string;
 }): Scenario {
   return createScenario(config.id, config.name)
     .category('edge-case')
     .tags('transfer', 'insufficient-balance', 'error')
-    .description(`Transfer ${config.amount} (more than available balance)`)
+    .description(`Transfer more than available balance (amount resolved at runtime)`)
     .withPrompt(`Send ${config.amount} ${TOKEN_PLACEHOLDER} to ${config.recipient}`)
     .expectText({
       contains: ['insufficient', 'balance'],

--- a/lib/dotbot-core/scenarioEngine/scenarios/testPrompts.ts
+++ b/lib/dotbot-core/scenarioEngine/scenarios/testPrompts.ts
@@ -30,11 +30,11 @@ export const HAPPY_PATH_TESTS: Scenario[] = [
     recipient: "Alice",
   }),
   
-  // Basic transfer that should FAIL (insufficient balance)
+  // Basic transfer that should FAIL (insufficient balance) — amount is dynamic so we never guess (works on Paseo 1000 PAS, Westend, etc.; no burnt amount)
   insufficientBalanceScenario({
     id: "happy-path-002",
-    name: "Large Transfer to Alice (Should Fail)",
-    amount: "100",
+    name: "Insufficient Balance (Should Fail)",
+    amount: "{{calc:balancePlusAmount(0.01)}}",
     recipient: "Alice",
   }),
   
@@ -130,22 +130,19 @@ export const AMBIGUITY_TESTS: Scenario[] = [];
 
 export const EDGE_CASE_TESTS: Scenario[] = [
   // Multi-transaction: Two sequential transfers where second would fail (insufficient balance)
-  // DYNAMIC TEST: Uses runtime balance calculation!
-  // IMPORTANT: Single prompt generates ONE ExecutionFlow with 2 transactions, allowing simulation to detect failure
-  // Both transfers would succeed individually, but second fails after first executes
+  // DYNAMIC: First transfer is a small fixed amount (minimal burn); second amount is runtime-calculated so it exceeds remaining balance.
+  // Single prompt = ONE ExecutionFlow with 2 transactions; works on any network (Paseo 1000 PAS, Westend, etc.).
   {
     id: 'edge-case-001',
     name: 'Multi-Transaction: Second Transfer Insufficient Balance (Dynamic)',
-    description: 'Two sequential transfers where each would succeed individually, but the second fails after the first executes. Uses dynamic balance calculation to ensure first transfer is safe (less than balance) and second transfer exceeds remaining balance. Works regardless of account balance (3 WND, 7 WND, 20 WND, etc.).',
+    description: 'Two sequential transfers: first is a small amount (0.1), second is calculated at runtime to exceed remaining balance so it fails. Minimal burn; works regardless of account balance.',
     category: 'edge-case',
     tags: ['multi-transaction', 'sequential', 'insufficient-balance', 'dynamic', 'runtime-calculation'],
     steps: [
       {
         id: 'step-1',
         type: 'prompt',
-        // Single prompt generates ONE ExecutionFlow with 2 transactions.
-        // First: 0.5 (small). Second: calc returns (remaining + 0.2) so second transfer fails after first.
-        input: 'Send 0.5 {{TOKEN}} to Alice, then send {{calc:insufficientBalance(0.5, 0.01)}} {{TOKEN}} to Bob',
+        input: 'Send 0.1 {{TOKEN}} to Alice, then send {{calc:insufficientBalance(0.1, 0.01)}} {{TOKEN}} to Bob',
       },
     ],
     expectations: [

--- a/lib/dotbot-core/scenarioEngine/scenarios/testPrompts.ts
+++ b/lib/dotbot-core/scenarioEngine/scenarios/testPrompts.ts
@@ -30,11 +30,11 @@ export const HAPPY_PATH_TESTS: Scenario[] = [
     recipient: "Alice",
   }),
   
-  // Basic transfer that should FAIL (insufficient balance) — amount is dynamic so we never guess (works on Paseo 1000 PAS, Westend, etc.; no burnt amount)
+  // Basic transfer that should FAIL (insufficient balance) — amount = moreThanBalance() so always above balance (works on any network; no guess, no burn)
   insufficientBalanceScenario({
     id: "happy-path-002",
     name: "Insufficient Balance (Should Fail)",
-    amount: "{{calc:balancePlusAmount(0.01)}}",
+    amount: "{{calc:moreThanBalance()}}",
     recipient: "Alice",
   }),
   


### PR DESCRIPTION
### Description: 
Removes burnt-in values for insufficient amount, amount is always calculated now, based on balance.

### What was changed:
#### Core Changes:
 - added `calculateMoreThanBalance()`
 - modified related `Scenario`s
 - select correct API (defaults to Asset Hub)

### How was it tested:
`npm run test`
manually tested