### PR TITLE
Adds RPC test script and RpcManager will wait for reply

### DIFF
--- a/lib/dotbot-core/executionEngine/signers/browserSigner.ts
+++ b/lib/dotbot-core/executionEngine/signers/browserSigner.ts
@@ -58,8 +58,7 @@ export class BrowserWalletSigner implements Signer {
     }
     const injector = await getWeb3FromAddress(address);
     return await extrinsic.signAsync(address, {
-      // @ts-expect-error - Polkadot.js type mismatch between @polkadot/extension-inject and @polkadot/api versions
-      signer: injector.signer,
+      signer: injector.signer as unknown as import('@polkadot/api/types').Signer,
     });
   }
   

--- a/lib/dotbot-core/executionEngine/signing/executionSigner.ts
+++ b/lib/dotbot-core/executionEngine/signing/executionSigner.ts
@@ -131,8 +131,7 @@ export async function signExtrinsic(
   
   const injector = await getWeb3FromAddress(address);
   return await extrinsic.signAsync(address, {
-    // @ts-expect-error - Polkadot.js type mismatch
-    signer: injector.signer,
+    signer: injector.signer as unknown as import('@polkadot/api/types').Signer,
   });
 }
 

--- a/lib/dotbot-core/rpcManager/RpcManager.ts
+++ b/lib/dotbot-core/rpcManager/RpcManager.ts
@@ -108,41 +108,26 @@ export class RpcManager {
   }
 
   /**
-   * Attempt to connect to an endpoint
+   * Attempt to connect to an endpoint.
+   *
+   * Does NOT wait for provider 'connected' — Polkadot nodes send nothing until we send a JSON-RPC
+   * request. We start ApiPromise.create(provider) immediately so the API sends the first request
+   * (metadata etc.) and we wait for that response; this avoids false "connection timeout".
    */
   private async tryConnect(endpoint: string): Promise<ApiPromise> {
     const startTime = Date.now();
     const API_INIT_TIMEOUT_MS = 12000; // 12 seconds - faster failure for slow testnet endpoints
     const DISCONNECT_GRACE_PERIOD_MS = 2000; // 2 seconds grace period for normal closures
-    const MAX_TOTAL_TIMEOUT_MS = Math.max(this.connectionTimeout + API_INIT_TIMEOUT_MS + 5000, 20000); // Maximum total time (connection + API init + buffer)
-    
+    const MAX_TOTAL_TIMEOUT_MS = Math.max(this.connectionTimeout + API_INIT_TIMEOUT_MS + 5000, 20000);
+
     return new Promise<ApiPromise>((resolve, reject) => {
       const provider = new WsProvider(endpoint);
       let apiInitTimeoutHandle: NodeJS.Timeout | null = null;
       let disconnectGraceTimer: NodeJS.Timeout | null = null;
       let maxTimeoutHandle: NodeJS.Timeout | null = null;
       let isResolved = false;
-      let isConnected = false;
       let apiInstance: ApiPromise | null = null;
-      
-      // Maximum timeout - ensures we ALWAYS reject if something hangs
-      maxTimeoutHandle = setTimeout(() => {
-        if (!isResolved) {
-          cleanup();
-          safeDisconnect();
-          const error = new Error(`Maximum timeout (${MAX_TOTAL_TIMEOUT_MS}ms) exceeded for endpoint. The system will try the next endpoint.`);
-          this.rpcLogger.error({ endpoint }, `Maximum timeout exceeded - forcing failover`);
-          reject(error);
-        }
-      }, MAX_TOTAL_TIMEOUT_MS);
-      
-      const connectionTimeoutHandle = setTimeout(() => {
-        if (!isResolved) {
-          cleanup();
-          reject(new Error(`Connection timeout (${this.connectionTimeout}ms). The system will try the next endpoint.`));
-        }
-      }, this.connectionTimeout);
-      
+
       const safeDisconnect = () => {
         try {
           if (provider && typeof provider.disconnect === 'function') {
@@ -152,11 +137,10 @@ export class RpcManager {
           // Ignore disconnect errors
         }
       };
-      
+
       const cleanup = () => {
         if (isResolved) return;
         isResolved = true;
-        clearTimeout(connectionTimeoutHandle);
         if (maxTimeoutHandle) {
           clearTimeout(maxTimeoutHandle);
           maxTimeoutHandle = null;
@@ -171,143 +155,66 @@ export class RpcManager {
         }
         safeDisconnect();
       };
-      
+
       const errorHandler = (error: Error | string | unknown) => {
-        if (isResolved) {
-          return;
-        }
-        
+        if (isResolved) return;
         cleanup();
-        
         const { message, error: errorObj } = this.normalizeError(error);
         this.rpcLogger.error({ endpoint, error: message }, `Provider error - triggering failover`);
         reject(errorObj);
       };
-      
+
       const disconnectedHandler = () => {
         if (isResolved) return;
-        
-        // If API instance already exists, allow initialization to complete
-        if (apiInstance) {
-          return;
-        }
-        
-        // Give a grace period for disconnections during initialization
-        if (isConnected && !disconnectGraceTimer) {
-          const gracePeriod = DISCONNECT_GRACE_PERIOD_MS;
-          
-          disconnectGraceTimer = setTimeout(() => {
-            if (!isResolved && !apiInstance) {
-              cleanup();
-              safeDisconnect();
-              const error = new Error(`Connection lost during initialization - endpoint disconnected (may be normal closure). The system will try the next endpoint.`);
-              this.rpcLogger.error({ endpoint }, `Disconnected during API initialization after grace period - forcing failover`);
-              reject(error);
-            }
-          }, gracePeriod);
-          return;
-        }
-        
-        // If not connected yet, reject immediately
-        if (!isConnected) {
-          cleanup();
-          safeDisconnect();
-          const error = new Error(`Connection lost during initialization - endpoint disconnected before connection established. The system will try the next endpoint.`);
-          this.rpcLogger.error({ endpoint }, `Disconnected before connection established - forcing failover`);
-          reject(error);
-          return;
-        }
+        if (apiInstance) return;
+        if (disconnectGraceTimer) return;
+        disconnectGraceTimer = setTimeout(() => {
+          if (!isResolved && !apiInstance) {
+            cleanup();
+            const err = new Error(`Connection lost during initialization - endpoint disconnected. The system will try the next endpoint.`);
+            this.rpcLogger.error({ endpoint }, `Disconnected during API initialization - forcing failover`);
+            reject(err);
+          }
+        }, DISCONNECT_GRACE_PERIOD_MS);
       };
-      
-      const connectedHandler = async () => {
-        if (isResolved) return;
-        isConnected = true;
-        clearTimeout(connectionTimeoutHandle);
-        
-        // Clear disconnect grace timer if connection is re-established
-        if (disconnectGraceTimer) {
-          clearTimeout(disconnectGraceTimer);
-          disconnectGraceTimer = null;
+
+      maxTimeoutHandle = setTimeout(() => {
+        if (!isResolved) {
+          cleanup();
+          reject(new Error(`Maximum timeout (${MAX_TOTAL_TIMEOUT_MS}ms) exceeded for endpoint. The system will try the next endpoint.`));
+          this.rpcLogger.error({ endpoint }, `Maximum timeout exceeded - forcing failover`);
         }
-        
-        try {
-          // Check if provider is still connected before starting API creation
-          if (!provider.isConnected) {
+      }, MAX_TOTAL_TIMEOUT_MS);
+
+      let apiPromise: Promise<ApiPromise>;
+      try {
+        apiPromise = ApiPromise.create({ provider });
+      } catch (syncError) {
+        cleanup();
+        const { message: errorMessage } = this.normalizeError(syncError);
+        reject(new Error(`Synchronous error during API creation: ${errorMessage}. The system will try the next endpoint.`));
+        this.rpcLogger.error({ endpoint }, `Synchronous error during API creation - forcing failover`);
+        return;
+      }
+
+      const timeoutPromise = new Promise<never>((_, timeoutReject) => {
+        apiInitTimeoutHandle = setTimeout(() => {
+          if (!isResolved) {
             cleanup();
-            safeDisconnect();
-            const error = new Error(`Provider disconnected before API initialization could start. The system will try the next endpoint.`);
-            this.rpcLogger.error({ endpoint }, `Provider disconnected before API creation - forcing failover`);
-            reject(error);
-            return;
+            timeoutReject(new Error(`API initialization timeout (${API_INIT_TIMEOUT_MS}ms) - endpoint may be slow or unresponsive. The system will try the next endpoint.`));
           }
-          
-          // Short delay after 'connected' so the WebSocket is fully ready for RPC (reduces "WebSocket is not connected" during getMetadata)
-          const STABILITY_DELAY_MS = 150;
-          await new Promise<void>((r) => setTimeout(r, STABILITY_DELAY_MS));
+        }, API_INIT_TIMEOUT_MS);
+      });
+
+      provider.on('error', errorHandler);
+      provider.on('disconnected', disconnectedHandler);
+
+      Promise.race([apiPromise, timeoutPromise])
+        .then((api) => {
           if (isResolved) return;
-          if (!provider.isConnected) {
-            cleanup();
-            safeDisconnect();
-            const error = new Error(`Provider disconnected during stability delay. The system will try the next endpoint.`);
-            this.rpcLogger.debug({ endpoint }, `Disconnected during ${STABILITY_DELAY_MS}ms stability delay - forcing failover`);
-            reject(error);
-            return;
-          }
-          
-          let apiPromise: Promise<ApiPromise>;
-          try {
-            apiPromise = ApiPromise.create({ provider });
-          } catch (syncError) {
-            cleanup();
-            safeDisconnect();
-            const { message: errorMessage } = this.normalizeError(syncError);
-            const error = new Error(`Synchronous error during API creation: ${errorMessage}. The system will try the next endpoint.`);
-            this.rpcLogger.error({ endpoint }, `Synchronous error during API creation - forcing failover`);
-            reject(error);
-            return;
-          }
-          
-          apiPromise = apiPromise.catch((promiseError) => {
-            if (isResolved) {
-              return Promise.reject(promiseError);
-            }
-            throw promiseError;
-          });
-          
-          const timeoutPromise = new Promise<never>((_, timeoutReject) => {
-            apiInitTimeoutHandle = setTimeout(() => {
-              if (!isResolved) {
-                cleanup();
-                safeDisconnect();
-                timeoutReject(new Error(`API initialization timeout (${API_INIT_TIMEOUT_MS}ms) - endpoint may be slow or unresponsive. The system will try the next endpoint.`));
-              }
-            }, API_INIT_TIMEOUT_MS);
-          });
-          
-          // Race between API creation and timeout - ensure all errors are caught
-          const api = await Promise.race([apiPromise, timeoutPromise]);
-          
-          // Check if a disconnect happened while we were waiting
-          if (isResolved) {
-            return;
-          }
-          
-          // Check if provider disconnected during API creation
-          if (!provider.isConnected) {
-            cleanup();
-            safeDisconnect();
-            const error = new Error(`Provider disconnected during API initialization. The system will try the next endpoint.`);
-            this.rpcLogger.error({ endpoint }, `Provider disconnected during API creation - forcing failover`);
-            reject(error);
-            return;
-          }
-          
+          // ApiPromise.create() resolved => provider responded to RPC; no need to gate on provider.isConnected
           apiInstance = api;
-          
-          if (isResolved) return;
           isResolved = true;
-          
-          // Clear all timeouts on success
           if (maxTimeoutHandle) {
             clearTimeout(maxTimeoutHandle);
             maxTimeoutHandle = null;
@@ -320,82 +227,32 @@ export class RpcManager {
             clearTimeout(disconnectGraceTimer);
             disconnectGraceTimer = null;
           }
-          
           const responseTime = Date.now() - startTime;
           this.healthTracker.markEndpointHealthy(endpoint, responseTime);
           resolve(api);
-        } catch (error) {
+        })
+        .catch((error) => {
+          if (isResolved) return;
           const { message: errorMessage } = this.normalizeError(error);
-          const normalizedErrorMessage = errorMessage.trim().toLowerCase();
-          const isFatalError = 
-            errorMessage.includes('FATAL') || 
+          const isFatalError =
+            errorMessage.includes('FATAL') ||
             errorMessage.includes('Unable to initialize the API') ||
-            normalizedErrorMessage.includes('fatal') ||
-            normalizedErrorMessage.includes('unable to initialize');
-          
-          const providerDisconnected = !provider.isConnected;
-          const isDisconnectionError = 
-            errorMessage.includes('disconnected') || 
+            errorMessage.toLowerCase().includes('fatal') ||
+            errorMessage.toLowerCase().includes('unable to initialize');
+          const isDisconnectionError =
+            errorMessage.includes('disconnected') ||
             errorMessage.includes('Normal Closure') ||
             errorMessage.includes('1000') ||
-            errorMessage.includes('FATAL') ||
-            errorMessage.includes('Unable to initialize') ||
             errorMessage.includes('WebSocket is not connected') ||
-            providerDisconnected;
-          
-          // If this is a disconnection/FATAL error and provider is disconnected, reject immediately
-          if ((isFatalError || isDisconnectionError || providerDisconnected) && !isResolved) {
-            if (disconnectGraceTimer) {
-              clearTimeout(disconnectGraceTimer);
-              disconnectGraceTimer = null;
-            }
-            
-            cleanup();
-            safeDisconnect();
-            
-            const isNormalClosure = errorMessage.includes('Normal Closure') || errorMessage.includes('1000');
-            const finalError = new Error(
-              isNormalClosure 
-                ? `Connection lost during initialization - endpoint disconnected with normal closure (1000). The system will try the next endpoint.`
-                : isFatalError
-                ? `API initialization failed - endpoint disconnected during metadata fetch. The system will try the next endpoint. Original error: ${errorMessage}`
-                : `Connection lost during API initialization: ${errorMessage}. The system will try the next endpoint.`
-            );
-            
-            this.rpcLogger.error({ endpoint, error: errorMessage }, `FATAL/disconnect error - forcing failover`);
-            reject(finalError);
-            return;
-          }
-          
-          // Check if promise was already resolved/rejected
-          if (isResolved) {
-            if (isFatalError || isDisconnectionError) {
-              this.rpcLogger.debug({ endpoint }, `FATAL/disconnect error caught but promise already resolved`);
-            }
-            return;
-          }
-          
+            !provider.isConnected;
           cleanup();
-          
-          const isNormalClosure = errorMessage.includes('Normal Closure') || errorMessage.includes('1000');
-          const finalError = isDisconnectionError 
-            ? new Error(
-                isNormalClosure 
-                  ? `Connection lost during initialization - endpoint disconnected with normal closure (1000). The system will try the next endpoint.`
-                  : isFatalError
-                  ? `API initialization failed - endpoint disconnected during metadata fetch. The system will try the next endpoint. Original error: ${errorMessage}`
-                  : `Connection lost during API initialization: ${errorMessage}. The system will try the next endpoint.`
-              )
-            : (error instanceof Error ? error : new Error(errorMessage));
-          
+          const finalError =
+            isFatalError || isDisconnectionError
+              ? new Error(`API initialization failed: ${errorMessage}. The system will try the next endpoint.`)
+              : error instanceof Error ? error : new Error(errorMessage);
           this.rpcLogger.error({ endpoint, error: errorMessage }, `Failed to initialize API - forcing failover`);
           reject(finalError);
-        }
-      };
-      
-      provider.on('connected', connectedHandler);
-      provider.on('error', errorHandler);
-      provider.on('disconnected', disconnectedHandler);
+        });
     });
   }
 
@@ -653,9 +510,10 @@ export class RpcManager {
   }
 
   /**
-   * Perform a health check on all endpoints
-   * This performs a lightweight connection test.
-   * Skips opening new connections when we already have a healthy read API (reduces connection churn and log noise).
+   * Perform a health check on all endpoints.
+   * Uses the same flow as tryConnect: open WebSocket, send RPC (via ApiPromise), wait for response.
+   * Polkadot nodes send nothing until we send a request, so we must send then wait (no "connected"-only check).
+   * Skips when we already have a healthy read API (reduces churn).
    */
   async performHealthCheck(): Promise<void> {
     if (this.currentReadApi?.isConnected) {
@@ -663,86 +521,33 @@ export class RpcManager {
       return;
     }
 
-    // Only probe a subset of endpoints per run to limit connection churn (prefer first/health-ordered)
     const endpointsToCheck = this.healthTracker.getOrderedEndpoints().slice(0, 5);
-    const checkPromises = endpointsToCheck.map(async (endpoint) => {
-      const endpointStartTime = Date.now();
-      try {
-        const provider = new WsProvider(endpoint);
-        
-        return new Promise<void>((resolve) => {
-          let isResolved = false;
-          
-          const safeResolve = () => {
-            if (isResolved) return;
-            isResolved = true;
-            resolve();
-          };
-          
-          const safeDisconnect = () => {
-            if (isResolved) return; // Prevent re-entry
-            try {
-              if (provider && typeof provider.disconnect === 'function') {
-                provider.disconnect();
-              }
-            } catch (err) {
-              // Ignore disconnect errors
-            }
-          };
-          
-          const connectedHandler = () => {
-            if (isResolved) return;
-            isResolved = true; // Set BEFORE disconnect to prevent re-entry
-            clearTimeout(timeout);
-            const responseTime = Date.now() - endpointStartTime;
-            safeDisconnect();
-            this.healthTracker.markEndpointHealthy(endpoint, responseTime);
-            safeResolve();
-          };
-          
-          const errorHandler = () => {
-            if (isResolved) return;
-            isResolved = true; // Set BEFORE disconnect to prevent re-entry
-            clearTimeout(timeout);
-            safeDisconnect();
-            this.healthTracker.markEndpointFailed(endpoint);
-            safeResolve();
-          };
-          
-          const timeout = setTimeout(() => {
-            if (isResolved) return;
-            isResolved = true; // Set BEFORE disconnect to prevent re-entry
-            safeDisconnect();
-            this.healthTracker.markEndpointFailed(endpoint);
-            safeResolve();
-          }, 5000);
-          
-          provider.on('connected', connectedHandler);
-          provider.on('error', errorHandler);
-          
-          if (provider.isConnected) {
-            if (!isResolved) {
-              isResolved = true;
-              clearTimeout(timeout);
-              const responseTime = Date.now() - endpointStartTime;
-              safeDisconnect();
-              this.healthTracker.markEndpointHealthy(endpoint, responseTime);
-              safeResolve();
-            }
-          }
-        });
-      } catch (error) {
-        this.healthTracker.markEndpointFailed(endpoint);
-      }
-    });
-    
-    await Promise.all(checkPromises);
-    const healthyCount = Array.from(this.healthMap.values()).filter(h => h.healthy).length;
-    this.rpcLogger.info({ 
-      healthyCount,
-      totalEndpoints: this.endpoints.length,
-      checked: endpointsToCheck.length
-    }, `Health check complete: ${healthyCount}/${this.endpoints.length} endpoints healthy (checked ${endpointsToCheck.length})`);
+    const HEALTH_CHECK_TIMEOUT_MS = 10000;
+
+    await Promise.all(
+      endpointsToCheck.map(async (endpoint) => {
+        const start = Date.now();
+        try {
+          const api = await Promise.race([
+            this.tryConnect(endpoint),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error('Health check timeout')), HEALTH_CHECK_TIMEOUT_MS)
+            ),
+          ]);
+          const responseTime = Date.now() - start;
+          await api.disconnect();
+          this.healthTracker.markEndpointHealthy(endpoint, responseTime);
+        } catch {
+          this.healthTracker.markEndpointFailed(endpoint);
+        }
+      })
+    );
+
+    const healthyCount = Array.from(this.healthMap.values()).filter((h) => h.healthy).length;
+    this.rpcLogger.info(
+      { healthyCount, totalEndpoints: this.endpoints.length, checked: endpointsToCheck.length },
+      `Health check complete: ${healthyCount}/${this.endpoints.length} endpoints healthy (checked ${endpointsToCheck.length})`
+    );
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -27,16 +27,21 @@
     "lint:core": "npm run lint --workspace=@dotbot/core",
     "lint:express": "npm run lint --workspace=@dotbot/express",
     "type-check": "npm run type-check --workspace=frontend && npm run type-check --workspace=backend --if-present",
-    "install:all": "npm install && npm run install --workspaces"
+    "install:all": "npm install && npm run install --workspaces",
+    "dedupe": "npm dedupe",
+    "test:rpc": "node scripts/test-rpc-endpoints.mjs",
+    "test:rpc:once": "node scripts/test-rpc-endpoints.mjs --once"
   },
   "overrides": {
     "@polkadot/util": "^14.0.1",
     "@polkadot/util-crypto": "^14.0.1",
     "@polkadot/keyring": "^14.0.1",
-    "@polkadot/rpc-provider": "^14.3.1"
+    "@polkadot/rpc-provider": "^14.3.1",
+    "@polkadot/types-codec": "^14.3.1"
   },
   "devDependencies": {
     "@stoplight/prism-cli": "^5.14.2",
-    "lerna": "^8.0.0"
+    "lerna": "^8.0.0",
+    "ws": "^8.18.0"
   }
 }

--- a/scripts/.rpc-stats.json
+++ b/scripts/.rpc-stats.json
@@ -1,0 +1,88 @@
+{
+  "endpoints": {
+    "wss://polkadot.api.onfinality.io/public-ws": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://polkadot-rpc.dwellir.com": {
+      "checks": 59,
+      "ok": 0
+    },
+    "wss://rpc.ibp.network/polkadot": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://polkadot.dotters.network": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://rpc.polkadot.io": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://statemint.api.onfinality.io/public-ws": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://statemint-rpc.dwellir.com": {
+      "checks": 59,
+      "ok": 0
+    },
+    "wss://rpc-asset-hub.polkadot.io": {
+      "checks": 59,
+      "ok": 0
+    },
+    "wss://paseo.rpc.amforc.com:443": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://paseo-rpc.dwellir.com": {
+      "checks": 59,
+      "ok": 0
+    },
+    "wss://rpc.ibp.network/paseo": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://paseo.dotters.network": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://pas-rpc.stakeworld.io": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://asset-hub-paseo-rpc.n.dwellir.com": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://sys.ibp.network/asset-hub-paseo": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://asset-hub-paseo.dotters.network": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://sys.turboflakes.io/asset-hub-paseo": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://westend.api.onfinality.io/public-ws": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://westend.public.curie.radiumblock.co/ws": {
+      "checks": 59,
+      "ok": 59
+    },
+    "wss://westmint.api.onfinality.io/public-ws": {
+      "checks": 59,
+      "ok": 0
+    },
+    "wss://sys.ibp.network/westmint": {
+      "checks": 59,
+      "ok": 0
+    }
+  }
+}

--- a/scripts/test-rpc-endpoints.mjs
+++ b/scripts/test-rpc-endpoints.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * Periodically tests Polkadot, Paseo, and Westend RPC endpoints and prints results.
+ *
+ * Correct RPC check: open WebSocket → send JSON-RPC request (system_chain) → wait for response.
+ * Nodes do not send anything until you send a request, so we must send first then wait.
+ *
+ * Per-endpoint uptime is persisted across runs in scripts/.rpc-stats.json.
+ *
+ * Usage (from repo root):
+ *   npm run test:rpc        — run every 60s (Ctrl+C to stop)
+ *   npm run test:rpc:once   — run once and exit
+ *
+ * Env: RPC_TEST_INTERVAL_MS overrides interval. Requires network access; uses `ws` only (no @polkadot/api).
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import WebSocket from 'ws';
+
+const STATS_FILE = path.join(process.cwd(), 'scripts', '.rpc-stats.json');
+
+const INTERVAL_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+const RPC_REQUEST = JSON.stringify({
+  id: 1,
+  jsonrpc: '2.0',
+  method: 'system_chain',
+  params: [],
+});
+
+const ENDPOINTS = {
+  Polkadot: {
+    relay: [
+      'wss://polkadot.api.onfinality.io/public-ws',
+      'wss://polkadot-rpc.dwellir.com',
+      'wss://rpc.ibp.network/polkadot',
+      'wss://polkadot.dotters.network',
+      'wss://rpc.polkadot.io',
+    ],
+    assetHub: [
+      'wss://statemint.api.onfinality.io/public-ws',
+      'wss://statemint-rpc.dwellir.com',
+      'wss://rpc-asset-hub.polkadot.io',
+    ],
+  },
+  Paseo: {
+    relay: [
+      'wss://paseo.rpc.amforc.com:443',
+      'wss://paseo-rpc.dwellir.com',
+      'wss://rpc.ibp.network/paseo',
+      'wss://paseo.dotters.network',
+      'wss://pas-rpc.stakeworld.io',
+    ],
+    assetHub: [
+      'wss://asset-hub-paseo-rpc.n.dwellir.com',
+      'wss://sys.ibp.network/asset-hub-paseo',
+      'wss://asset-hub-paseo.dotters.network',
+      'wss://sys.turboflakes.io/asset-hub-paseo',
+    ],
+  },
+  Westend: {
+    relay: [
+      'wss://westend.api.onfinality.io/public-ws',
+      'wss://westend.public.curie.radiumblock.co/ws',
+    ],
+    assetHub: [
+      'wss://westmint.api.onfinality.io/public-ws',
+      'wss://sys.ibp.network/westmint',
+    ],
+  },
+};
+
+function testEndpoint(url) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    let settled = false;
+    const done = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close();
+      } catch (_) {}
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      done({ ok: false, error: 'Timeout (no response)' });
+    }, REQUEST_TIMEOUT_MS);
+
+    let ws;
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      done({ ok: false, error: err?.message || String(err) });
+      return;
+    }
+
+    ws.on('open', () => {
+      ws.send(RPC_REQUEST);
+    });
+
+    ws.on('message', (data) => {
+      const latency = Date.now() - start;
+      let chain = '';
+      try {
+        const j = JSON.parse(data.toString());
+        if (j.error) {
+          done({ ok: false, error: j.error.message || JSON.stringify(j.error) });
+          return;
+        }
+        if (j.result != null) chain = String(j.result);
+      } catch (_) {}
+      done({ ok: true, chain: chain || '—', latency });
+    });
+
+    ws.on('error', (err) => {
+      done({ ok: false, error: err?.message || String(err) });
+    });
+
+    ws.on('close', () => {
+      if (!settled) done({ ok: false, error: 'Connection closed before response' });
+    });
+  });
+}
+
+function shorten(url) {
+  try {
+    const u = new URL(url);
+    return u.hostname.replace(/^www\./, '') + (u.pathname !== '/' ? u.pathname.slice(0, 20) : '');
+  } catch {
+    return url.slice(0, 40);
+  }
+}
+
+function formatResult(url, result, historical) {
+  const short = shorten(url);
+  let uptimeStr = '';
+  if (historical && historical.checks > 0) {
+    const pct = Math.round((historical.ok / historical.checks) * 1000) / 10;
+    uptimeStr = `  (${pct}% uptime, ${historical.checks} checks)`;
+  }
+  if (result.ok) {
+    const latencyStr = result.latency != null ? ` ${result.latency}ms` : '';
+    return `  ✓ ${short.padEnd(42)} ${result.chain}${latencyStr}${uptimeStr}`;
+  }
+  return `  ✗ ${short.padEnd(42)} ${result.error}${uptimeStr}`;
+}
+
+function printStatistics(stats, errorCounts) {
+  console.log('\n  Connection statistics');
+  console.log('  ' + '─'.repeat(50));
+  let totalUp = 0;
+  let totalDown = 0;
+  for (const [network, s] of Object.entries(stats)) {
+    const relayPct = s.relayTotal > 0 ? Math.round((s.relayUp / s.relayTotal) * 100) : 0;
+    const hubPct = s.hubTotal > 0 ? Math.round((s.hubUp / s.hubTotal) * 100) : 0;
+    console.log(`  ${network}`);
+    console.log(`    Relay:     ${s.relayUp}/${s.relayTotal} (${relayPct}%)`);
+    console.log(`    Asset Hub: ${s.hubUp}/${s.hubTotal} (${hubPct}%)`);
+    totalUp += s.up;
+    totalDown += s.down;
+  }
+  console.log('  ' + '─'.repeat(50));
+  const total = totalUp + totalDown;
+  const overallPct = total > 0 ? Math.round((totalUp / total) * 100) : 0;
+  console.log(`  TOTAL     ${totalUp} up, ${totalDown} down — ${total} endpoints (${overallPct}% reachable)`);
+  if (errorCounts && Object.keys(errorCounts).length > 0) {
+    console.log('  Failures by reason:');
+    const sorted = Object.entries(errorCounts).sort((a, b) => b[1] - a[1]).slice(0, 8);
+    for (const [reason, count] of sorted) {
+      const short = reason.length > 48 ? reason.slice(0, 45) + '...' : reason;
+      console.log(`    ${short}: ${count}`);
+    }
+  }
+}
+
+function printIndividualUptime(historicalByUrl, endpoints) {
+  console.log('\n  Individual node uptime (all runs)');
+  console.log('  ' + '─'.repeat(50));
+  for (const [network, { relay, assetHub }] of Object.entries(endpoints)) {
+    for (const [label, urls] of [
+      ['Relay', relay],
+      ['Asset Hub', assetHub],
+    ]) {
+      const groupName = `${network} ${label}`;
+      const withHistory = urls
+        .map((url) => ({ url, h: historicalByUrl[url] }))
+        .filter(({ h }) => h && h.checks > 0)
+        .map(({ url, h }) => ({ url, pct: (h.ok / h.checks) * 100, ...h }))
+        .sort((a, b) => b.pct - a.pct);
+      if (withHistory.length === 0) continue;
+      console.log(`  ${groupName}:`);
+      for (const { url, pct, ok, checks } of withHistory) {
+        const short = shorten(url);
+        const pctStr = (Math.round(pct * 10) / 10).toFixed(1);
+        console.log(`    ${short.padEnd(40)} ${pctStr}%  (${ok}/${checks})`);
+      }
+    }
+  }
+  console.log('  ' + '─'.repeat(50));
+}
+
+async function loadHistoricalStats() {
+  try {
+    const raw = await fs.readFile(STATS_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    return data?.endpoints && typeof data.endpoints === 'object' ? data.endpoints : {};
+  } catch {
+    return {};
+  }
+}
+
+async function saveHistoricalStats(endpoints) {
+  try {
+    await fs.writeFile(STATS_FILE, JSON.stringify({ endpoints }, null, 2), 'utf8');
+  } catch (err) {
+    console.error('  [Warning] Could not save .rpc-stats.json:', err?.message);
+  }
+}
+
+async function runOnce() {
+  const time = new Date().toISOString();
+  console.log('\n' + '─'.repeat(80));
+  console.log(` RPC endpoint check — ${time}`);
+  console.log('─'.repeat(80));
+
+  const historicalByUrl = await loadHistoricalStats();
+  const stats = {};
+  const errorCounts = {};
+  const resultsByUrl = {};
+
+  for (const [network, { relay, assetHub }] of Object.entries(ENDPOINTS)) {
+    stats[network] = { relayUp: 0, relayTotal: relay.length, hubUp: 0, hubTotal: assetHub.length, up: 0, total: 0 };
+    console.log(`\n${network}`);
+    console.log('  Relay chain:');
+    for (const url of relay) {
+      const result = await testEndpoint(url);
+      resultsByUrl[url] = result;
+      if (result.ok) stats[network].relayUp++;
+      else errorCounts[result.error] = (errorCounts[result.error] || 0) + 1;
+      const hist = historicalByUrl[url];
+      console.log(formatResult(url, result, hist));
+    }
+    console.log('  Asset Hub:');
+    for (const url of assetHub) {
+      const result = await testEndpoint(url);
+      resultsByUrl[url] = result;
+      if (result.ok) stats[network].hubUp++;
+      else errorCounts[result.error] = (errorCounts[result.error] || 0) + 1;
+      const hist = historicalByUrl[url];
+      console.log(formatResult(url, result, hist));
+    }
+    stats[network].up = stats[network].relayUp + stats[network].hubUp;
+    stats[network].total = stats[network].relayTotal + stats[network].hubTotal;
+    stats[network].down = stats[network].total - stats[network].up;
+  }
+
+  for (const [url, result] of Object.entries(resultsByUrl)) {
+    const prev = historicalByUrl[url] || { checks: 0, ok: 0 };
+    historicalByUrl[url] = {
+      checks: prev.checks + 1,
+      ok: prev.ok + (result.ok ? 1 : 0),
+    };
+  }
+  await saveHistoricalStats(historicalByUrl);
+
+  printStatistics(stats, errorCounts);
+  printIndividualUptime(historicalByUrl, ENDPOINTS);
+  console.log('\n' + '─'.repeat(80));
+}
+
+async function main() {
+  const interval = process.env.RPC_TEST_INTERVAL_MS
+    ? parseInt(process.env.RPC_TEST_INTERVAL_MS, 10)
+    : INTERVAL_MS;
+  const once = process.argv.includes('--once');
+
+  try {
+    await runOnce();
+    if (once) {
+      process.exit(0);
+      return;
+    }
+    console.log(`\nNext run in ${interval / 1000}s (Ctrl+C to stop, or use --once for single run).\n`);
+    setInterval(runOnce, interval);
+  } catch (err) {
+    console.error('Fatal:', err?.message || err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
### Description: 
Adds RPC test script and RpcManager will wait for reply.

### What was changed:
#### Core Changes:
 - Does not wait for '`connected`'. As soon as the provider is created, it calls `ApiPromise.create(provider)` and races that with the API init timeout and the max total timeout.

####  Build/Config Changes
 - added `test-rpc-endpoints.cjs`


### How was it tested:
`npm run test`
manually tested